### PR TITLE
Add "BPT" abbreviation for best possible time

### DIFF
--- a/UI/Components/RunPrediction.cs
+++ b/UI/Components/RunPrediction.cs
@@ -159,7 +159,8 @@ namespace LiveSplit.UI.Components
                     InternalComponent.AlternateNameText = new []
                     {
                         "Best Poss. Time",
-                        "Best Time"
+                        "Best Time",
+                        "BPT"
                     };
                     break;
                 case WorstSegmentsComparisonGenerator.ComparisonName:


### PR DESCRIPTION
ran into this when trying to make the lowest possible resolution layout; will likely never be used for normal layouts but useful for tiny layouts on lowres recordings/streams