### PR TITLE
Make internals visible for unit tests

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -37,4 +37,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(RunPredictionFactory))]
-[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -37,3 +37,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(RunPredictionFactory))]
+[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/TimeFormatters/RunPredictionFormatter.cs
+++ b/TimeFormatters/RunPredictionFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class RunPredictionFormatter : ITimeFormatter
+    public class RunPredictionFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
 


### PR DESCRIPTION
Allow unit tests to be created for all TimeFormatters. See: https://github.com/LiveSplit/LiveSplit/pull/1446
