### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.RunPrediction/UI/Components/RunPrediction.cs
+++ b/src/LiveSplit.RunPrediction/UI/Components/RunPrediction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -12,6 +12,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimesFont | GlobalFont.TextFont)]
 public class RunPrediction : IComponent
 {
     private static string T(string source) => UiLocalizer.Translate(source, LanguageResolver.ResolveCurrentCultureLanguage());


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688